### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Architect. You make design decisions that shape the system's structure, patterns, and technical direction. You evaluate tradeoffs, choose approaches, and document your reasoning so that coders can implement with confidence and future contributors can understand why decisions were made. You design — you never implement.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go 1.19 (e2e tests)
 - **Module:** Azure NoOps overlay for Azure Redis Cache
 - **CI:** GitHub Actions (terraform fmt, validate, tflint, plan)

--- a/.github/agents/coder.agent.md
+++ b/.github/agents/coder.agent.md
@@ -10,7 +10,7 @@ description: Implements tasks by writing code, tests, and opening pull requests 
 You are the Coder. You implement tasks by writing code. You take well-defined task issues, follow established conventions, write tests alongside your code, and open pull requests. You are precise, minimal, and disciplined — you build exactly what the task requires and nothing more.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go 1.19 (e2e tests)
 - **Package Manager:** Go modules (test/go.mod)
 - **Test Framework:** Terratest + terraform-module-test-helper (Go)

--- a/.github/agents/documenter.agent.md
+++ b/.github/agents/documenter.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Documenter. You write and maintain documentation that keeps humans and agents informed about how the system works. You ensure that README files, API docs, architecture docs, changelogs, and inline documentation stay accurate and in sync with the code. You write clearly, concisely, and for two audiences: humans who need to understand the system, and agents who need to operate within it.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go 1.19 (e2e tests)
 - **Doc Build Command:** `terraform-docs markdown .` (generates README sections)
 - **Doc Preview Command:** `mkdocs serve`

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Orchestrator. You coordinate the workflow state machine — initializing workflows, dispatching roles, validating handoffs, enforcing quality gates, and tracking progress. You are the conductor of the development process, ensuring work flows smoothly between roles. You never implement, design, review, or test — you coordinate.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4), Go 1.19 (e2e tests)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4), Go 1.19 (e2e tests)
 
 ## Model Requirements
 

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit"]
 You are the Planner. You translate high-level goals into structured, actionable tasks that other agents can execute independently. You are the bridge between what a human wants and what a coder can build. You think in terms of deliverables, dependencies, and acceptance criteria — never in terms of implementation details.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go 1.19 (e2e tests)
 
 ## Model Requirements

--- a/.github/agents/product-owner.agent.md
+++ b/.github/agents/product-owner.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Product Owner. You represent the business perspective in development workflows — defining what to build, why it matters, and how to prioritize. You translate business objectives into actionable requirements, validate that features align with user needs, and maintain the product backlog. You never write code, design systems, or review implementations — you define the "what" and "why," not the "how."
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4), Azure Redis Cache overlay module
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4), Azure Redis Cache overlay module
 
 ## Model Requirements
 

--- a/.github/agents/qa-lead.agent.md
+++ b/.github/agents/qa-lead.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the QA Lead. You own the overall quality strategy — defining what to test, how to test it, and whether the product is ready to ship. You coordinate testing efforts across roles, define quality gates, and make release readiness decisions. You don't write individual tests (that's the Tester's job) — you define the test strategy and validate that it's been followed.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4), Terratest (Go e2e tests)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4), Terratest (Go e2e tests)
 
 ## Model Requirements
 

--- a/.github/agents/refactorer.agent.md
+++ b/.github/agents/refactorer.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Refactorer. You improve code quality without changing behavior. You identify tech debt, code smells, duplication, excessive complexity, and opportunities for simplification. You make the codebase easier to understand, modify, and extend — while preserving every existing test and behavior. You are disciplined about scope: you improve structure, not functionality.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go 1.19 (e2e tests)
 - **Test Command:** `cd test && go test ./...`
 - **Lint Command:** `terraform fmt -check -recursive -diff`, `tflint --recursive`

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Reviewer. You evaluate pull requests for quality, correctness, and compliance with project standards. You are the quality gate between implementation and merge. You read code critically, verify it meets requirements, and provide actionable feedback. You approve good work and request changes on work that isn't ready. You never modify the code yourself.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go 1.19 (e2e tests)
 - **Test Command:** `cd test && go test ./...`
 

--- a/.github/agents/security-auditor.agent.md
+++ b/.github/agents/security-auditor.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search"]
 You are the Security Auditor. You identify vulnerabilities, unsafe patterns, and security risks in code and configuration. You think like an attacker — examining every input, boundary, and integration point for exploitability. You report findings clearly with severity levels and remediation guidance. You are a specialist, not a gatekeeper — you inform, you don't block.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go 1.19 (e2e tests)
 - **Test Command:** `cd test && go test ./...`
 

--- a/.github/agents/tester.agent.md
+++ b/.github/agents/tester.agent.md
@@ -11,7 +11,7 @@ tools: ["read", "search", "edit", "execute"]
 You are the Tester. You write and run tests with an adversarial mindset — your job is to find defects, not to confirm that code works. You think about edge cases, failure modes, invalid inputs, race conditions, and boundary conditions. You are the last line of defense before code reaches users. You break things so users don't have to.
 
 ## Project Knowledge
-- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, azurenoopsutils ~> 1.0.4)
+- **Tech Stack:** Terraform >= 1.3, Azure (azurerm ~> 3.22, popsrox-utils ~> 1.0.4)
 - **Languages:** HCL (Terraform), Go 1.19 (e2e tests)
 - **Package Manager:** Go modules (test/go.mod)
 - **Test Framework:** Terratest + terraform-module-test-helper (Go)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [v1.0.2](https://github.com/azurenoops/terraform-azurerm-overlays-redis/tree/v1.0.2) (2023-04-28)
+## [v1.0.2](https://github.com/POps-Rox/terraform-az-overlays-redis/tree/v1.0.2) (2023-04-28)
 
-## [v1.0.1](https://github.com/azurenoops/terraform-azurerm-overlays-redis/tree/v1.0.1) (2023-04-28)
+## [v1.0.1](https://github.com/POps-Rox/terraform-az-overlays-redis/tree/v1.0.1) (2023-04-28)
 
-## [v1.0.0](https://github.com/azurenoops/terraform-azurerm-overlays-redis/tree/v1.0.0) (2023-02-23)
+## [v1.0.0](https://github.com/POps-Rox/terraform-az-overlays-redis/tree/v1.0.0) (2023-02-23)
 
 
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ module "mod_redis" {
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache)                                                         | resource    |
 | [azurerm_redis_firewall_rule.redis_fw_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule)                                 | resource    |
 | [azurerm_storage_account.redis_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account)                                         | resource    |
-| [popsrox_utils_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                          | data source |
-| [popsrox_utils_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                                 | data source |
-| [popsrox_utils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                         | data source |
+| [popsrox_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                          | data source |
+| [popsrox_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                                 | data source |
+| [popsrox_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                         | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection)                        | data source |
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/redis_cache)                                                      | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                                                 | data source |

--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ module "mod_redis" {
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache)                                                         | resource    |
 | [azurerm_redis_firewall_rule.redis_fw_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule)                                 | resource    |
 | [azurerm_storage_account.redis_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account)                                         | resource    |
-| [popsrox_utils_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                          | data source |
-| [popsrox_utils_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                                 | data source |
-| [popsrox_utils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                         | data source |
+| [popsrox_utils_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                          | data source |
+| [popsrox_utils_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                                 | data source |
+| [popsrox_utils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                         | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection)                        | data source |
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/redis_cache)                                                      | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                                                 | data source |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Azure NoOps Redis Cache Overlay Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-redis/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-redis/azurerm/)
 
-This Overlay terraform module can create a Redis Cache and manage related parameters (Threat protection, Redis Cache FW Rules, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a Redis Cache and manage related parameters (Threat protection, Redis Cache FW Rules, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 
@@ -146,21 +146,21 @@ module "mod_redis" {
 | Name                                                                                        | Version  |
 |---------------------------------------------------------------------------------------------|----------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform)                   | >= 1.3   |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)                         | ~> 3.22  |
 
 ## Providers
 
 | Name                                                                                  | Version  |
 |---------------------------------------------------------------------------------------|----------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm)                         | ~> 3.22  |
 
 ## Modules
 
 | Name                                                                                                            | Source                                       | Version  |
 |-----------------------------------------------------------------------------------------------------------------|----------------------------------------------|----------|
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
 
 ## Resources
 
@@ -176,9 +176,9 @@ module "mod_redis" {
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache)                                                         | resource    |
 | [azurerm_redis_firewall_rule.redis_fw_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule)                                 | resource    |
 | [azurerm_storage_account.redis_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account)                                         | resource    |
-| [azurenoopsutils_resource_name.data_storage](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name)                          | data source |
-| [azurenoopsutils_resource_name.redis](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name)                                 | data source |
-| [azurenoopsutils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name)                         | data source |
+| [popsrox_utils_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                          | data source |
+| [popsrox_utils_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                                 | data source |
+| [popsrox_utils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                         | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection)                        | data source |
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/redis_cache)                                                      | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                                                 | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,9 +176,9 @@ module "mod_redis" {
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache)                                                         | resource    |
 | [azurerm_redis_firewall_rule.redis_fw_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule)                                 | resource    |
 | [azurerm_storage_account.redis_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account)                                         | resource    |
-| [popsrox_utils_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                          | data source |
-| [popsrox_utils_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                                 | data source |
-| [popsrox_utils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                         | data source |
+| [popsrox_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                          | data source |
+| [popsrox_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                                 | data source |
+| [popsrox_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                         | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection)                        | data source |
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/redis_cache)                                                      | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                                                 | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,9 +176,9 @@ module "mod_redis" {
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache)                                                         | resource    |
 | [azurerm_redis_firewall_rule.redis_fw_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule)                                 | resource    |
 | [azurerm_storage_account.redis_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account)                                         | resource    |
-| [popsrox_utils_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                          | data source |
-| [popsrox_utils_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                                 | data source |
-| [popsrox_utils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                         | data source |
+| [popsrox_utils_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                          | data source |
+| [popsrox_utils_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                                 | data source |
+| [popsrox_utils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name)                         | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection)                        | data source |
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/redis_cache)                                                      | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                                                 | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Azure NoOps Redis Cache Overlay Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-redis/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-redis/azurerm/)
 
-This Overlay terraform module can create a Redis Cache and manage related parameters (Threat protection, Redis Cache FW Rules, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Overlay terraform module can create a Redis Cache and manage related parameters (Threat protection, Redis Cache FW Rules, Private Endpoints, etc.) to be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 
@@ -146,21 +146,21 @@ module "mod_redis" {
 | Name                                                                                        | Version  |
 |---------------------------------------------------------------------------------------------|----------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform)                   | >= 1.3   |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)                         | ~> 3.22  |
 
 ## Providers
 
 | Name                                                                                  | Version  |
 |---------------------------------------------------------------------------------------|----------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm)                         | ~> 3.22  |
 
 ## Modules
 
 | Name                                                                                                            | Source                                       | Version  |
 |-----------------------------------------------------------------------------------------------------------------|----------------------------------------------|----------|
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
 
 ## Resources
 
@@ -176,9 +176,9 @@ module "mod_redis" {
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache)                                                         | resource    |
 | [azurerm_redis_firewall_rule.redis_fw_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_firewall_rule)                                 | resource    |
 | [azurerm_storage_account.redis_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account)                                         | resource    |
-| [azurenoopsutils_resource_name.data_storage](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name)                          | data source |
-| [azurenoopsutils_resource_name.redis](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name)                                 | data source |
-| [azurenoopsutils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name)                         | data source |
+| [popsrox_utils_resource_name.data_storage](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                          | data source |
+| [popsrox_utils_resource_name.redis](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                                 | data source |
+| [popsrox_utils_resource_name.redis_fw_rule](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name)                         | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection)                        | data source |
 | [azurerm_redis_cache.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/redis_cache)                                                      | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group)                                                 | data source |

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,6 +5,6 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_redis_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_redis_rg.*.resource_group_location, [""]), 0)
-  redis_name          = coalesce(var.custom_name, data.popsrox_utils_resource_name.redis.result)
-  storage_name        = coalesce(var.data_persistence_storage_custom_name, data.popsrox_utils_resource_name.data_storage.result)
+  redis_name          = coalesce(var.custom_name, data.popsrox_resource_name.redis.result)
+  storage_name        = coalesce(var.data_persistence_storage_custom_name, data.popsrox_resource_name.data_storage.result)
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,6 +5,6 @@ locals {
 
   resource_group_name = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_redis_rg.*.resource_group_name, [""]), 0)
   location            = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_redis_rg.*.resource_group_location, [""]), 0)
-  redis_name          = coalesce(var.custom_name, data.azurenoopsutils_resource_name.redis.result)
-  storage_name        = coalesce(var.data_persistence_storage_custom_name, data.azurenoopsutils_resource_name.data_storage.result)
+  redis_name          = coalesce(var.custom_name, data.popsrox_utils_resource_name.redis.result)
+  storage_name        = coalesce(var.data_persistence_storage_custom_name, data.popsrox_utils_resource_name.data_storage.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -1,4 +1,4 @@
-data "azurenoopsutils_resource_name" "redis" {
+data "popsrox_utils_resource_name" "redis" {
   name          = var.workload_name
   resource_type = "azurerm_redis_cache"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -8,7 +8,7 @@ data "azurenoopsutils_resource_name" "redis" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "data_storage" {
+data "popsrox_utils_resource_name" "data_storage" {
   name          = "${var.workload_name}redis"
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -18,7 +18,7 @@ data "azurenoopsutils_resource_name" "data_storage" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "redis_fw_rule" {
+data "popsrox_utils_resource_name" "redis_fw_rule" {
   for_each = var.authorized_cidrs
 
   name          = var.workload_name

--- a/naming.tf
+++ b/naming.tf
@@ -1,4 +1,4 @@
-data "popsrox_utils_resource_name" "redis" {
+data "popsrox_resource_name" "redis" {
   name          = var.workload_name
   resource_type = "azurerm_redis_cache"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -8,7 +8,7 @@ data "popsrox_utils_resource_name" "redis" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "data_storage" {
+data "popsrox_resource_name" "data_storage" {
   name          = "${var.workload_name}redis"
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -18,7 +18,7 @@ data "popsrox_utils_resource_name" "data_storage" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "redis_fw_rule" {
+data "popsrox_resource_name" "redis_fw_rule" {
   for_each = var.authorized_cidrs
 
   name          = var.workload_name

--- a/resources.redis.firewall.rules.tf
+++ b/resources.redis.firewall.rules.tf
@@ -3,7 +3,7 @@
 
 resource "azurerm_redis_firewall_rule" "redis_fw_rule" {
   for_each = var.authorized_cidrs
-  name     = var.use_naming ? data.azurenoopsutils_resource_name.redis_fw_rule[each.key].result : each.key
+  name     = var.use_naming ? data.popsrox_utils_resource_name.redis_fw_rule[each.key].result : each.key
 
   redis_cache_name    = azurerm_redis_cache.redis.name
   resource_group_name = local.resource_group_name

--- a/resources.redis.firewall.rules.tf
+++ b/resources.redis.firewall.rules.tf
@@ -3,7 +3,7 @@
 
 resource "azurerm_redis_firewall_rule" "redis_fw_rule" {
   for_each = var.authorized_cidrs
-  name     = var.use_naming ? data.popsrox_utils_resource_name.redis_fw_rule[each.key].result : each.key
+  name     = var.use_naming ? data.popsrox_resource_name.redis_fw_rule[each.key].result : each.key
 
   redis_cache_name    = azurerm_redis_cache.redis.name
   resource_group_name = local.resource_group_name

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,4 +1,4 @@
-module github.com/azurenoops/terraform-azurerm-overlays-redis
+module github.com/POps-Rox/terraform-az-overlays-redis
 
 go 1.19
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.22"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -5,9 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,8 +5,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.22"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops` provider references with the new `POps-Rox/popsrox-utils` provider across all Terraform files, documentation, agent configs, test code, and changelog.

## Changes
- `versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`, updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: All `data "azurenoopsutils_resource_name"` → `data "popsrox_utils_resource_name"`
- `locals.naming.tf`: All `data.azurenoopsutils_resource_name.` → `data.popsrox_utils_resource_name.`
- `resources.redis.firewall.rules.tf`: Same data source reference update
- `README.md` / `docs/index.md`: Updated provider/module registry URLs and table entries from azurenoops → POps-Rox
- `CHANGELOG.md`: Updated GitHub URLs from azurenoops org to POps-Rox
- `test/go.mod`: Updated module path from azurenoops to POps-Rox
- `.github/agents/*.md` (11 files): Updated tech stack entry from `azurenoopsutils ~> 1.0.4` to `popsrox-utils ~> 1.0.4`

## Testing
- `terraform fmt -recursive` passes with no changes
- Zero remaining `azurenoops` references in any `.tf`, `.md`, or `.go` file

Closes #4